### PR TITLE
fix: replace hardcoded Supabase URLs and add missing accessibility attributes

### DIFF
--- a/src/components/HeroScene.jsx
+++ b/src/components/HeroScene.jsx
@@ -83,7 +83,7 @@ export default function HeroScene() {
     // ── LOAD EAGLE ─────────────────────────────────────────
     // Eagle has baked PBR textures — preserve them, don't override
     let eagleRef = null
-    loader.load('https://aujimkqsmxjaeusspxtp.supabase.co/storage/v1/object/public/model/mechanical_eagle.glb', (gltf) => {
+    loader.load(`${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/model/mechanical_eagle.glb`, (gltf) => {
       const eagle = gltf.scene
 
       eagle.traverse(child => {
@@ -123,7 +123,7 @@ export default function HeroScene() {
 
     // ── LOAD CAP ───────────────────────────────────────────
     // Hat has no textures — flat material colors only
-    loader.load('https://aujimkqsmxjaeusspxtp.supabase.co/storage/v1/object/public/model/graduation_hat.glb', (gltf) => {
+    loader.load(`${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/model/graduation_hat.glb`, (gltf) => {
       const cap = gltf.scene
 
       cap.traverse(child => {

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -2,7 +2,6 @@ import { ChevronRight } from 'lucide-react';
 import { FaGithub } from 'react-icons/fa';
 import { FaInstagram } from 'react-icons/fa';
 import { FaLinkedin } from 'react-icons/fa';
-import { FaYoutube } from 'react-icons/fa';
 
 
 import { Link } from 'react-router-dom';
@@ -114,6 +113,7 @@ export default function Footer() {
                   href="https://github.com/piush365/diploma-dost"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="GitHub repository"
                   className="p-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)] hover:bg-[var(--accent)]/5 transition-all"
                 >
                   <FaGithub size={20} />
@@ -122,6 +122,7 @@ export default function Footer() {
                   href="https://www.linkedin.com/in/piush-gogi-90a44737b/"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="LinkedIn profile"
                   className="p-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)] hover:bg-[var(--accent)]/5 transition-all"
                 >
                   <FaLinkedin size={20} />
@@ -130,6 +131,7 @@ export default function Footer() {
                   href="https://www.instagram.com/piush_without_a_y/"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="Instagram profile"
                   className="p-2 rounded-lg bg-[var(--surface)] border border-[var(--border)] text-[var(--text-muted)] hover:text-[var(--accent)] hover:border-[var(--accent)] hover:bg-[var(--accent)]/5 transition-all"
                 >
                   <FaInstagram size={20} />

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -39,7 +39,7 @@ export default function Navbar() {
           style={{ textDecoration: 'none' }}
         >
           <img
-            src={"https://aujimkqsmxjaeusspxtp.supabase.co/storage/v1/object/public/model/dd-logo.png"}
+            src={`${import.meta.env.VITE_SUPABASE_URL}/storage/v1/object/public/model/dd-logo.png`}
             alt="Diploma Dost"
             style={{
               width: '52px',
@@ -78,6 +78,7 @@ export default function Navbar() {
               <Link
           key={link.path}
           to={link.path}
+          aria-current={isActive ? 'page' : undefined}
           className={`font-ui text-sm px-2 py-2 rounded-lg transition-colors duration-200 outline-none ${isActive ? 'text-[#e8453c] bg-[#e8453c]/10' : 'text-[#888] hover:text-[#f0ede6] hover:bg-[#1a1a1a]'}`}
           onFocus={e => {
             e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent)'
@@ -114,6 +115,7 @@ export default function Navbar() {
             className="p-2 rounded-lg text-[#888] hover:text-[#f0ede6] transition-colors duration-200 outline-none"
             onClick={() => setOpen(!open)}
             aria-label={open ? 'Close menu' : 'Open menu'}
+            aria-expanded={open}
             onFocus={e => {
               e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent)'
               e.currentTarget.style.color = 'var(--text)'
@@ -141,6 +143,7 @@ export default function Navbar() {
                 key={link.path}
                 to={link.path}
                 onClick={() => setOpen(false)}
+                aria-current={isActive ? 'page' : undefined}
                 className={`font-ui text-base px-4 py-3 rounded-lg transition-colors duration-200 outline-none ${isActive ? 'text-[#e8453c] bg-[#e8453c]/10' : 'text-[#888] hover:text-[#f0ede6] hover:bg-[#1a1a1a]'}`}
                 onFocus={e => {
                   e.currentTarget.style.boxShadow = '0 0 0 2px var(--accent)'


### PR DESCRIPTION
## Summary

- Replace 3 hardcoded `aujimkqsmxjaeusspxtp` Supabase project URLs in `Navbar.jsx` and `HeroScene.jsx` with `import.meta.env.VITE_SUPABASE_URL`
- Add `aria-current="page"` to active nav links (desktop + mobile) and `aria-expanded` to the hamburger toggle in `Navbar.jsx`
- Add `aria-label` to the 3 icon-only social links in `Footer.jsx` (GitHub, LinkedIn, Instagram)
- Remove unused `FaYoutube` import from `Footer.jsx`

## Test plan

- [ ] Verify logo, eagle model, and graduation cap still load (Supabase URL change)
- [ ] Navigate between pages and confirm `aria-current="page"` is present on the active link (inspect element)
- [ ] Toggle mobile menu and confirm `aria-expanded` flips between `true`/`false`
- [ ] Run a screen reader or axe audit on the footer — social links should now announce their destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added descriptive labels to footer social media links
  * Navigation now indicates the current active page in both desktop and mobile menus
  * Mobile menu button displays expanded/collapsed state
* **General Updates**
  * Updated asset loading configuration for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->